### PR TITLE
[JRO] Allow existing user to be a superadmin #66

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -47,6 +47,7 @@ mount Thredded::Engine => '/forum'
 
 [The initializer]: https://github.com/jayroh/thredded/blob/master/lib/generators/thredded/install/templates/initializer.rb
 
+
 ## Development dependencies
 
 * PostgreSQL & MySQL - `brew install postgres mysql`
@@ -69,29 +70,46 @@ There are a few things you need in your app to get things looking just right.
 
 1. Add a to_s method to your user model. The following example assumes a column in my user model called `name`:
 
-```ruby
-class User < ActiveRecord::Base
-  def to_s
-    name
+  ```ruby
+  class User < ActiveRecord::Base
+    def to_s
+      name
+    end
   end
-end
-```
+  ```
 
 2. Ensure you have a view layout that thredded will wrap around its views.
 
-A couple of notes with regards to your layout.
+  A couple of notes with regards to your layout.
 
-* When using route helpers -- eg: `new_session_path`, et al -- make sure to prepend main_app to the helper: `main_app.new_session_path` as rails engines like thredded will not know about those routes' existence unless explicitly told so.
-* As noted above, by default thredded will look for a layout file in your application called `thredded.html.erb`. If you would like to use something else, like your main application layout, you may change it to that in your initializer.
-* The chosen layout has two content_tags available to yield - `:thredded_page_title` and `:thredded_page_id`. The views within thredded pass those up through to your layout if you would like to use them.  Example layout:
+  * When using route helpers -- eg: `new_session_path`, et al -- make sure to prepend main_app 
+    to the helper: `main_app.new_session_path` as rails engines like thredded will not know 
+    about those routes' existence unless explicitly told so.
+  * As noted above, by default thredded will look for a layout file in your application 
+    called `thredded.html.erb`. If you would like to use something else, like your main application
+    layout, you may change it to that in your initializer.
+  * The chosen layout has two content_tags available to yield - `:thredded_page_title` and 
+    `:thredded_page_id`. The views within thredded pass those up through to your layout if you 
+    would like to use them.  Example layout:
 
-```html
-<html>
-  <head>
-  <title>My Application | <%= yield :thredded_page_title %></title>
-  </head>
-  <body id="<%= yield :thredded_page_id %>">
-    <%= yield %>
-  </body>
-</html>
-```
+  ```html
+  <html>
+    <head>
+    <title>My Application | <%= yield :thredded_page_title %></title>
+    </head>
+    <body id="<%= yield :thredded_page_id %>">
+      <%= yield %>
+    </body>
+  </html>
+  ```
+
+3. Make you, or one of your users, a super-admin so they'll have the permissions to create a new forum. 
+
+  ```
+  rake thredded:superadmin[joel] # bash
+  rake "thredded:superadmin[yourname]" # zsh
+  ```
+
+  Two examples are given for bash and zsh. Zsh typically reserves brackets, `[]`, for other uses 
+  hence the wrapping with quotes. Pro-tip: did you know [you can escape the brackets by 
+  default](http://kinopyo.com/blog/escape-square-bracket-by-default-in-zsh/)?

--- a/app/commands/thredded/authorize_superadmin.rb
+++ b/app/commands/thredded/authorize_superadmin.rb
@@ -1,0 +1,28 @@
+module Thredded
+  class AuthorizeSuperadmin
+    def initialize(username)
+      @username = username
+    end
+
+    def run
+      fail Thredded::Errors::UserNotFound if user.blank?
+
+      details = Thredded::UserDetail.where(user: user).first_or_initialize
+      details.update_attributes!(superadmin: true)
+    end
+
+    protected
+
+    attr_reader :username
+
+    private
+
+    def user
+      @user ||= begin
+        column = Thredded.user_name_column
+        klass = Thredded.user_class
+        klass.where("#{column} = '#{username}'").first
+      end
+    end
+  end
+end

--- a/lib/tasks/thredded_tasks.rake
+++ b/lib/tasks/thredded_tasks.rake
@@ -1,4 +1,9 @@
 namespace :thredded do
+  desc 'Assign thredded superadmin status to a user'
+  task :superadmin, [:username] => :environment do |_, args|
+    Thredded::AuthorizeSuperadmin.new(args.username).run
+  end
+
   desc 'Destroy messageboard and all related data'
   task :destroy, [:slug] => :environment do |_, args|
     Thredded::MessageboardDestroyer.new(args.slug).run

--- a/lib/thredded/errors.rb
+++ b/lib/thredded/errors.rb
@@ -3,6 +3,12 @@ module Thredded
   end
 
   module Errors
+    class UserNotFound < Thredded::Error
+      def message
+        'This user could not be found. Is their name misspelled?'
+      end
+    end
+
     class PrivateTopicNotFound < Thredded::Error
       def message
         'This private topic does not exist.'

--- a/spec/commands/thredded/authorize_superadmin_spec.rb
+++ b/spec/commands/thredded/authorize_superadmin_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+module Thredded
+  describe AuthorizeSuperadmin, '#run' do
+    it 'makes that user a superadmin' do
+      user = create(:user, name: 'joel')
+      AuthorizeSuperadmin.new('joel').run
+
+      expect(user.thredded_user_detail.superadmin).to eq true
+    end
+
+    it 'updates the user to be a superadmin' do
+      user = create(:user, :superadmin, name: 'joel')
+      AuthorizeSuperadmin.new('joel').run
+
+      expect(user.thredded_user_detail.superadmin).to eq true
+    end
+
+    it 'fails with the right exception if a user is not found' do
+      expect { AuthorizeSuperadmin.new('carl').run }
+        .to raise_error(Thredded::Errors::UserNotFound)
+    end
+  end
+end


### PR DESCRIPTION
Allowing any old person to create the first forum is probably a "bad
idea". This commit now introduces the capabilities to assign a user, via
a rake task, the role of a "superadmin". These super-people will then,
eventually, be the only ones able to create a new forum, either at
first, or in the future - period.

Up until now forums can only be created once you JUST install the engine
(or unless you dig into the console and do it manually) and that's just
dumb.