### PR TITLE
[JRO] Not finding messageboard is not Exception'al

### DIFF
--- a/app/commands/thredded/ensure_role_exists.rb
+++ b/app/commands/thredded/ensure_role_exists.rb
@@ -1,6 +1,6 @@
 module Thredded
   class EnsureRoleExists
-    def initialize(params={})
+    def initialize(params = {})
       @user = params.fetch(:user)
       @messageboard = params.fetch(:messageboard)
     end

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -28,9 +28,7 @@ module Thredded
     end), class_name: Thredded::Role
 
     def self.find_by_slug(slug)
-      friendly.find(slug)
-    rescue ActiveRecord::RecordNotFound
-      raise Thredded::Errors::MessageboardNotFound
+      where(slug: slug).first
     end
 
     def self.default_scope

--- a/spec/dummy/app/themes/default/views/thredded/search/_form.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/search/_form.html.erb
@@ -1,4 +1,4 @@
-<% if messageboard %>
+<% if messageboard.try(:persisted?) %>
   <%= form_tag messageboard_topics_path(messageboard), method: 'get' do %>
     <%= label :q, :search, 'Search', for: 'q', class: 'show-for-small', data: {toggle: '#q'} %>
     <%= text_field_tag(:q, params[:q], { placeholder: 'Search Topics and Posts', type: 'search', class: 'input-search' }) %>

--- a/spec/dummy/app/themes/default/views/thredded/search/_form.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/search/_form.html.erb
@@ -1,5 +1,7 @@
-<%= form_tag messageboard_topics_path(messageboard), method: 'get' do %>
-  <%= label :q, :search, 'Search', for: 'q', class: 'show-for-small', data: {toggle: '#q'} %>
-  <%= text_field_tag(:q, params[:q], { placeholder: 'Search Topics and Posts', type: 'search', class: 'input-search' }) %>
-  <%= submit_tag('Search', name: '') %>
+<% if messageboard %>
+  <%= form_tag messageboard_topics_path(messageboard), method: 'get' do %>
+    <%= label :q, :search, 'Search', for: 'q', class: 'show-for-small', data: {toggle: '#q'} %>
+    <%= text_field_tag(:q, params[:q], { placeholder: 'Search Topics and Posts', type: 'search', class: 'input-search' }) %>
+    <%= submit_tag('Search', name: '') %>
+  <% end %>
 <% end %>

--- a/spec/dummy/app/themes/default/views/thredded/shared/_top_nav.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/shared/_top_nav.html.erb
@@ -11,12 +11,12 @@
         <% end %>
       </li>
 
-      <% if messageboard %>
-      <li class="main--nav--notification--preferences">
-        <%= link_to edit_messageboard_preferences_path(messageboard) do %>
-        <span>Notification Settings</span>
-        <% end %>
-      </li>
+      <% if messageboard.try(:persisted?) %>
+        <li class="main--nav--notification--preferences">
+          <%= link_to edit_messageboard_preferences_path(messageboard) do %>
+          <span>Notification Settings</span>
+          <% end %>
+        </li>
       <% end %>
 
       <li class="main--nav--sign-out">

--- a/spec/dummy/app/themes/default/views/thredded/shared/_topic_nav.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/shared/_topic_nav.html.erb
@@ -8,7 +8,7 @@
     </li>
   </ul>
 
-  <% if messageboard %>
+  <% if messageboard.try(:persisted?) %>
     <ul class="topic-navigation">
       <li class="topic-navigation--public">
         <%= link_to 'Topics', messageboard_topics_path(messageboard) %>

--- a/spec/dummy/app/themes/default/views/thredded/topics/new.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/topics/new.html.erb
@@ -11,5 +11,6 @@
 <%= render 'thredded/topics/form',
   messageboard: messageboard,
   topic: @new_topic,
+  css_class: 'topic-form is-compact',
   placeholder: 'Start a New Topic'
   %>

--- a/spec/models/thredded/messageboard_spec.rb
+++ b/spec/models/thredded/messageboard_spec.rb
@@ -186,9 +186,8 @@ module Thredded
     end
 
     context 'when a messageboard is not found' do
-      it 'raises Thredded::Errors::MessageboardNotFound' do
-        expect { Messageboard.find_by_slug('rubbish') }
-          .to raise_error(Thredded::Errors::MessageboardNotFound)
+      it 'returns nil' do
+        expect(Messageboard.find_by_slug('rubbish')).to eq nil
       end
     end
   end

--- a/spec/support/features/page_object/new_messageboard.rb
+++ b/spec/support/features/page_object/new_messageboard.rb
@@ -42,7 +42,7 @@ module PageObject
     end
 
     def click_new_messageboard
-      find('.button-wide').click
+      find('.messageboards--new-action').click
     end
   end
 end


### PR DESCRIPTION
Current situation:

1. you call `messageboard` from a view
2. `def messageboard` looks for it via the slug in the params hash
3. it has no param, or that messageboard passed in via param does not exist
4. it says "whoops. doesn't exist. I'm raising an exception"

This causes an issue when you're at the root of the thredded engine and your layout uses some code that's looking for a messageboard ... resulting in an infinite redirect loop.

Bummer.

This PR changes that behavior to only return nil on that scope and let people deal with it accordingly where it is being called.