### PR TITLE
[JRO] Active public and private topic nav(s)

### DIFF
--- a/app/commands/thredded/ensure_role_exists.rb
+++ b/app/commands/thredded/ensure_role_exists.rb
@@ -1,0 +1,20 @@
+module Thredded
+  class EnsureRoleExists
+    def initialize(params={})
+      @user = params.fetch(:user)
+      @messageboard = params.fetch(:messageboard)
+    end
+
+    def run
+      Thredded::Role.where(
+        user: user,
+        messageboard: messageboard,
+        level: 'member',
+      ).first_or_create
+    end
+
+    private
+
+    attr_reader :user, :messageboard
+  end
+end

--- a/app/controllers/thredded/private_topics_controller.rb
+++ b/app/controllers/thredded/private_topics_controller.rb
@@ -35,9 +35,14 @@ module Thredded
       @private_topic = PrivateTopicForm.new(new_private_topic_params)
       @private_topic.save
 
+      EnsureRoleExists
+        .new(user: current_user, messageboard: messageboard)
+        .run
+
       NotifyPrivateTopicUsersJob
         .queue
         .send_notifications(@private_topic.private_topic.id)
+
       UserResetsPrivateTopicToUnread
         .new(@private_topic.private_topic, current_user)
         .run

--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -56,6 +56,11 @@ module Thredded
     def create
       @new_topic = TopicForm.new(new_topic_params)
       @new_topic.save
+
+      EnsureRoleExists
+        .new(user: current_user, messageboard: messageboard)
+        .run
+
       redirect_to messageboard_topics_path(messageboard)
     end
 

--- a/spec/commands/thredded/ensure_role_exists_spec.rb
+++ b/spec/commands/thredded/ensure_role_exists_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+module Thredded
+  describe EnsureRoleExists, '#run' do
+    it 'creates a role if it does not exist' do
+      user = create(:user)
+      messageboard = create(:messageboard)
+
+      EnsureRoleExists.new(user: user, messageboard: messageboard).run
+
+      roles = Thredded::Role.all
+      role = roles.first
+
+      expect(roles.count).to eq 1
+      expect(role.user).to eq user
+      expect(role.messageboard).to eq messageboard
+    end
+
+    it 'will not create one if it already exists' do
+      user = create(:user)
+      messageboard = create(:messageboard)
+      create(:role, user: user, messageboard: messageboard)
+
+      EnsureRoleExists.new(user: user, messageboard: messageboard).run
+      roles = Thredded::Role.all
+      role = roles.first
+
+      expect(roles.count).to eq 1
+      expect(role.user).to eq user
+      expect(role.messageboard).to eq messageboard
+    end
+  end
+end

--- a/spec/dummy/app/themes/default/assets/stylesheets/layout/_topic-navigation.scss
+++ b/spec/dummy/app/themes/default/assets/stylesheets/layout/_topic-navigation.scss
@@ -24,9 +24,17 @@
 
 }
 
-.topic-navigation--active {
+%topic-navigation--active {
   border-bottom: 1px solid $action-color;
   margin-bottom: -2px;
+}
+
+#thredded_topics_index .topic-navigation--public {
+  @extend %topic-navigation--active;
+}
+
+#thredded_private_topics_index .topic-navigation--private {
+  @extend %topic-navigation--active;
 }
 
 .topic-navigation--unread {

--- a/spec/dummy/app/themes/default/views/thredded/private_topics/_form.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/private_topics/_form.html.erb
@@ -1,11 +1,9 @@
-<h3 class="post-form--title">New Private Topic</h3>
-
 <%= form_for [messageboard, private_topic],
   url: messageboard_private_topics_path(messageboard, @private_topic),
   html: { class: css_class } do |form| %>
 
-  <ul class="form-list">
-    <li>
+  <ul class="form-list on-top">
+    <li class="title">
       <%= form.label :title %>
       <%= form.text_field :title, { placeholder: placeholder, autofocus: 'autofocus' } %>
     </li>

--- a/spec/dummy/app/themes/default/views/thredded/private_topics/_form.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/private_topics/_form.html.erb
@@ -5,7 +5,7 @@
   <ul class="form-list on-top">
     <li class="title">
       <%= form.label :title %>
-      <%= form.text_field :title, { placeholder: placeholder, autofocus: 'autofocus' } %>
+      <%= form.text_field :title, { placeholder: placeholder } %>
     </li>
 
     <li>

--- a/spec/dummy/app/themes/default/views/thredded/shared/_topic_nav.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/shared/_topic_nav.html.erb
@@ -8,17 +8,19 @@
     </li>
   </ul>
 
-  <ul class="topic-navigation">
-    <li class="topic-navigation--active">
-      <%= link_to 'Topics', messageboard_topics_path(messageboard) %>
-    </li>
-    <li>
-      <%= link_to messageboard_private_topics_path(messageboard), class: "unread-#{unread_private_topics_count}" do %>
-        Private Topics 
-        <% unless unread_private_topics_count == 0 %>
-          <span class="topic-navigation--unread"><%= unread_private_topics_count %></span>
+  <% if messageboard %>
+    <ul class="topic-navigation">
+      <li class="topic-navigation--public">
+        <%= link_to 'Topics', messageboard_topics_path(messageboard) %>
+      </li>
+      <li class="topic-navigation--private">
+        <%= link_to messageboard_private_topics_path(messageboard), class: "unread-#{unread_private_topics_count}" do %>
+          Private Topics
+          <% unless unread_private_topics_count == 0 %>
+            <span class="topic-navigation--unread"><%= unread_private_topics_count %></span>
+          <% end %>
         <% end %>
-      <% end %>
-    </li>
-  </ul>
+      </li>
+    </ul>
+  <% end %>
 </div>


### PR DESCRIPTION
* When you are on the *public* topics list the navigation should be visually "active".
* When you are on the *private* topics list the navigation should be visually "active".

Up until now only the public topics link was active.

* Also only show the topic navigation links if there is a `messageboard`
  object available. When you are on the main messageboard listing you
  should not be able to see those two links.

* * *

Added another commit that will make someone a member of a messageboard, if they are not already, when they create a new topic, private or public.