### PR TITLE
[JRO] Get breadcrumbs nice and situated. re #95

### DIFF
--- a/spec/dummy/app/themes/default/assets/stylesheets/layout/_topic-navigation.scss
+++ b/spec/dummy/app/themes/default/assets/stylesheets/layout/_topic-navigation.scss
@@ -24,7 +24,9 @@
 
 }
 
+#thredded_new_topic .topic-navigation--public,
 #thredded_topics_index .topic-navigation--public,
+#thredded_new_private_topic .topic-navigation--private,
 #thredded_private_topics_index .topic-navigation--private {
   border-bottom: 1px solid $action-color;
   margin-bottom: -2px;

--- a/spec/dummy/app/themes/default/views/thredded/messageboards/index.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/messageboards/index.html.erb
@@ -7,7 +7,11 @@
   </script>
 <% end %>
 <% content_for :thredded_breadcrumbs do %>
-  <%= render 'thredded/shared/messageboard_breadcrumbs' %>
+  <ul class="navigation-breadcrumbs">
+    <li>
+      <%= link_to 'All Message Boards', messageboards_path %>
+    </li>
+  </ul>
 <% end %>
 
 <%= content_tag :section, class: 'main-section messageboards' do %>

--- a/spec/dummy/app/themes/default/views/thredded/messageboards/index.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/messageboards/index.html.erb
@@ -6,6 +6,9 @@
     thredded.timestamps.init();
   </script>
 <% end %>
+<% content_for :thredded_breadcrumbs do %>
+  <%= render 'thredded/shared/messageboard_breadcrumbs' %>
+<% end %>
 
 <%= content_tag :section, class: 'main-section messageboards' do %>
   <%= render @messageboards %>

--- a/spec/dummy/app/themes/default/views/thredded/private_topics/index.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/private_topics/index.html.erb
@@ -7,6 +7,9 @@
     thredded.timestamps.init();
   </script>
 <% end %>
+<% content_for :thredded_breadcrumbs do %>
+  <%= render 'thredded/shared/messageboard_topics_breadcrumbs' %>
+<% end %>
 
 <%= content_tag :section, class: 'main-section private-topics' do %>
   <% if @private_topics.empty? -%>

--- a/spec/dummy/app/themes/default/views/thredded/private_topics/new.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/private_topics/new.html.erb
@@ -7,6 +7,9 @@
     thredded.privateTopicForm.init();
   </script>
 <% end %>
+<% content_for :thredded_breadcrumbs do %>
+  <%= render 'thredded/shared/messageboard_topics_breadcrumbs' %>
+<% end %>
 
 <%= content_tag :section, class: 'main-section private-topics-form' do %>
   <%= render 'thredded/private_topics/form',

--- a/spec/dummy/app/themes/default/views/thredded/private_topics/show.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/private_topics/show.html.erb
@@ -8,6 +8,9 @@
     thredded.timestamps.init();
   </script>
 <% end %>
+<% content_for :thredded_breadcrumbs do %>
+  <%= render 'thredded/shared/messageboard_topics_breadcrumbs' %>
+<% end %>
 
 <%= content_tag_for :section, private_topic, class: 'main-section private-topic' do %>
   <header class="topic-header">

--- a/spec/dummy/app/themes/default/views/thredded/shared/_messageboard_breadcrumbs.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/shared/_messageboard_breadcrumbs.html.erb
@@ -1,0 +1,5 @@
+<ul class="navigation-breadcrumbs">
+  <li>
+    <%= link_to 'All Message Boards', messageboards_path %>
+  </li>
+</ul>

--- a/spec/dummy/app/themes/default/views/thredded/shared/_messageboard_breadcrumbs.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/shared/_messageboard_breadcrumbs.html.erb
@@ -1,5 +1,0 @@
-<ul class="navigation-breadcrumbs">
-  <li>
-    <%= link_to 'All Message Boards', messageboards_path %>
-  </li>
-</ul>

--- a/spec/dummy/app/themes/default/views/thredded/shared/_messageboard_topics_breadcrumbs.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/shared/_messageboard_topics_breadcrumbs.html.erb
@@ -1,0 +1,8 @@
+<ul class="navigation-breadcrumbs">
+  <li>
+    <%= link_to 'All Message Boards', messageboards_path %>
+  </li>
+  <li>
+    <%= link_to messageboard.name, messageboard_topics_path(messageboard) %>
+  </li>
+</ul>

--- a/spec/dummy/app/themes/default/views/thredded/shared/_topic_nav.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/shared/_topic_nav.html.erb
@@ -1,12 +1,5 @@
 <div class="main-navigation">
-  <ul class="navigation-breadcrumbs">
-    <li>
-      <a href="#">All Message Boards</a>
-    </li>
-    <li>
-      <a href="#">Meta</a>
-    </li>
-  </ul>
+  <%= yield :thredded_breadcrumbs %>
 
   <% if messageboard.try(:persisted?) %>
     <ul class="topic-navigation">

--- a/spec/dummy/app/themes/default/views/thredded/topics/index.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/topics/index.html.erb
@@ -7,6 +7,9 @@
     thredded.timestamps.init();
   </script>
 <% end %>
+<% content_for :thredded_breadcrumbs do %>
+  <%= render 'thredded/shared/messageboard_topics_breadcrumbs' %>
+<% end %>
 
 <%= content_tag :section, class: 'main-section topics' do %>
   <%= render 'thredded/topics/form',

--- a/spec/dummy/app/themes/default/views/thredded/topics/new.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/topics/new.html.erb
@@ -7,6 +7,9 @@
     thredded.postForm.init();
   </script>
 <% end %>
+<% content_for :thredded_breadcrumbs do %>
+  <%= render 'thredded/shared/messageboard_topics_breadcrumbs' %>
+<% end %>
 
 <%= render 'thredded/topics/form',
   messageboard: messageboard,

--- a/spec/dummy/app/themes/default/views/thredded/topics/show.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/topics/show.html.erb
@@ -7,6 +7,9 @@
     thredded.timestamps.init();
   </script>
 <% end %>
+<% content_for :thredded_breadcrumbs do %>
+  <%= render 'thredded/shared/messageboard_topics_breadcrumbs' %>
+<% end %>
 
 <%= content_tag_for :section, topic, class: "main-section #{user_topic.css_class}" do %>
   <header class="topic-header">


### PR DESCRIPTION
Breadcrumbs are easy in this theme. There are two states:

1. From the top-level, the messageboards listing
2. Inside a messageboard itself - you see a link to the top-level
   messageboard listing, or a link to the topics listing for the
   messageboard.

That's it.

Abstracting it out into partials and feeding them in through yield tags
allows them to be sprinkled around where they need to be.

* Add some CSS to add an active state to the "new" form pages for topics
  and private topics.