### PR TITLE
[JRO] Change body selectors

### DIFF
--- a/spec/dummy/app/themes/default/views/layouts/thredded.html.erb
+++ b/spec/dummy/app/themes/default/views/layouts/thredded.html.erb
@@ -7,7 +7,7 @@
     <%= csrf_meta_tag %>
   </head>
 
-  <%= content_tag(:body, id: (yield :thredded_page_id), class: 'layout-application') do %>
+  <body class="layout-application <%= yield :thredded_page_id %>" id="<%= yield :thredded_page_id %>">
     <%= render 'thredded/shared/icons_svg' %>
 
     <div class="main-container">
@@ -27,5 +27,5 @@
       thredded = (typeof thredded === 'undefined') ? new Thredded : thredded;
       thredded.currentlyOnline.init();
     </script>
-  <% end %>
+  </body>
 </html>

--- a/spec/dummy/app/themes/default/views/thredded/messageboards/index.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/messageboards/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, 'Messageboards' %>
-<% content_for :thredded_page_id, 'thredded_messageboards_index' %>
+<% content_for :thredded_page_id, 'thredded-messageboards-index' %>
 <% content_for :thredded_javascript do %>
   <script>
     thredded = new Thredded;

--- a/spec/dummy/app/themes/default/views/thredded/messageboards/new.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/messageboards/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, 'Create a New Messageboard' %>
-<% content_for :thredded_page_id, 'thredded_messageboards_new' %>
+<% content_for :thredded_page_id, 'thredded-messageboards-new' %>
 
 <%= form_for @messageboard do |f| %>
   <ul class="form-list">

--- a/spec/dummy/app/themes/default/views/thredded/posts/edit.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/posts/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, 'Edit Post' %>
-<% content_for :thredded_page_id, 'thredded_edit_post' %>
+<% content_for :thredded_page_id, 'thredded-edit-post' %>
 <% content_for :thredded_javascript do %>
   <script>
     thredded = new Thredded;

--- a/spec/dummy/app/themes/default/views/thredded/private_topics/index.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/private_topics/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, 'Private Topics' %>
-<% content_for :thredded_page_id, 'thredded_private_topics_index' %>
+<% content_for :thredded_page_id, 'thredded-private-topics-index' %>
 <% content_for :thredded_javascript do %>
   <script>
     thredded = new Thredded;

--- a/spec/dummy/app/themes/default/views/thredded/private_topics/new.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/private_topics/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, 'Create a New Private Topic' %>
-<% content_for :thredded_page_id, 'thredded_new_private_topic' %>
+<% content_for :thredded_page_id, 'thredded-new-private-topic' %>
 <% content_for :thredded_javascript do %>
   <script>
     thredded = new Thredded;

--- a/spec/dummy/app/themes/default/views/thredded/private_topics/show.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/private_topics/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, private_topic.title %>
-<% content_for :thredded_page_id, 'thredded_posts' %>
+<% content_for :thredded_page_id, 'thredded-posts' %>
 <% content_for :thredded_javascript do %>
   <script>
     thredded = new Thredded;

--- a/spec/dummy/app/themes/default/views/thredded/themes/show.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/themes/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, "Theme Preview" %>
-<% content_for :thredded_page_id, 'thredded_theme' %>
+<% content_for :thredded_page_id, 'thredded-theme' %>
 <% content_for :thredded_javascript do %>
   <script>
     thredded = new Thredded;

--- a/spec/dummy/app/themes/default/views/thredded/topics/by_category.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/topics/by_category.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, 'Topic Categories' %>
-<% content_for :thredded_page_id, 'thredded_topic_categories' %>
+<% content_for :thredded_page_id, 'thredded-topic-categories' %>
 
 <% content_for :breadcrumbs do %>
   <ul class="breadcrumbs">

--- a/spec/dummy/app/themes/default/views/thredded/topics/edit.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/topics/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, "Edit \"#{topic.title}\"" %>
-<% content_for :thredded_page_id, 'thredded_edit_topic' %>
+<% content_for :thredded_page_id, 'thredded-edit-topic' %>
 
 <header>
   <nav>

--- a/spec/dummy/app/themes/default/views/thredded/topics/index.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/topics/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, 'Topics' %>
-<% content_for :thredded_page_id, 'thredded_topics_index' %>
+<% content_for :thredded_page_id, 'thredded-topics-index' %>
 <% content_for :thredded_javascript do %>
   <script>
     thredded = new Thredded;

--- a/spec/dummy/app/themes/default/views/thredded/topics/new.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/topics/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, 'Create a New Topic' %>
-<% content_for :thredded_page_id, 'thredded_new_topic' %>
+<% content_for :thredded_page_id, 'thredded-new-topic' %>
 <% content_for :thredded_javascript do %>
   <script>
     thredded = new Thredded;

--- a/spec/dummy/app/themes/default/views/thredded/topics/search.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/topics/search.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, 'Search Results' %>
-<% content_for :thredded_page_id, 'thredded_topic_search_results' %>
+<% content_for :thredded_page_id, 'thredded-topic-search-results' %>
 
 <% content_for :breadcrumbs do %>
   <ul class="breadcrumbs">

--- a/spec/dummy/app/themes/default/views/thredded/topics/show.html.erb
+++ b/spec/dummy/app/themes/default/views/thredded/topics/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :thredded_page_title, topic.title %>
-<% content_for :thredded_page_id, 'thredded_posts' %>
+<% content_for :thredded_page_id, 'thredded-posts' %>
 <% content_for :thredded_javascript do %>
   <script>
     thredded = new Thredded;

--- a/spec/support/features/page_object/new_messageboard.rb
+++ b/spec/support/features/page_object/new_messageboard.rb
@@ -30,7 +30,7 @@ module PageObject
     end
 
     def on_the_messageboard_list?
-      has_css? 'body#thredded_messageboards_index'
+      has_css? 'body#thredded-messageboards-index'
     end
 
     def visit_messageboard_list


### PR DESCRIPTION
HoundCI suggests not using id selectors for a previous PR so this
changes that to include both the <body> id and classes.

Also do not use underscores on css, instead use hyphens.