### PR TITLE
User links and timestamps

### DIFF
--- a/app/decorators/thredded/base_topic_decorator.rb
+++ b/app/decorators/thredded/base_topic_decorator.rb
@@ -11,38 +11,6 @@ module Thredded
       __getobj__
     end
 
-    def updated_at_timeago
-      if updated_at.nil?
-        <<-eohtml.html_safe.strip_heredoc
-          <abbr>
-            a little while ago
-          </abbr>
-        eohtml
-      else
-        <<-eohtml.html_safe.strip_heredoc
-          <abbr class="timeago" title="#{updated_at_utc}">
-            #{updated_at_str}
-          </abbr>
-        eohtml
-      end
-    end
-
-    def created_at_timeago
-      if created_at.nil?
-        <<-eohtml.html_safe.strip_heredoc
-          <abbr class="started_at">
-            a little while ago
-          </abbr>
-        eohtml
-      else
-        <<-eohtml.html_safe.strip_heredoc
-          <abbr class="started_at timeago" title="#{created_at_utc}">
-            #{created_at_str}
-          </abbr>
-        eohtml
-      end
-    end
-
     private
 
     def updated_at_str

--- a/app/decorators/thredded/base_user_topic_decorator.rb
+++ b/app/decorators/thredded/base_user_topic_decorator.rb
@@ -3,7 +3,7 @@ module Thredded
     extend ActiveModel::Naming
     include ActiveModel::Conversion
 
-    delegate :created_at_timeago, :last_user_link, :original, :updated_at_timeago, to: :topic
+    delegate :original, to: :topic
 
     class << self
       # @return [Class<ActiveRecord::Base>]

--- a/app/decorators/thredded/post_decorator.rb
+++ b/app/decorators/thredded/post_decorator.rb
@@ -15,33 +15,8 @@ module Thredded
       end
     end
 
-    def user_link
-      if post.user
-        user_path = Thredded.user_path(post.user)
-        "<a href='#{user_path}'>#{post.user}</a>".html_safe
-      else
-        '<a href="#">?</a>'.html_safe
-      end
-    end
-
     def original
       post
-    end
-
-    def created_at_timeago
-      if created_at.nil?
-        <<-eohtml.strip_heredoc.html_safe
-          <abbr>
-            a little while ago
-          </abbr>
-        eohtml
-      else
-        <<-eohtml.strip_heredoc.html_safe
-          <abbr class="timeago" title="#{created_at_utc}">
-            #{created_at_str}
-          </abbr>
-        eohtml
-      end
     end
 
     def avatar_url

--- a/app/decorators/thredded/private_topic_decorator.rb
+++ b/app/decorators/thredded/private_topic_decorator.rb
@@ -19,15 +19,5 @@ module Thredded
       classes << 'private_topic'
       classes.join(' ')
     end
-
-    def user_link
-      user_path = Thredded.user_path(user)
-      "<a href='#{user_path}'>#{user}</a>".html_safe
-    end
-
-    def last_user_link
-      last_user_path = Thredded.user_path(last_user)
-      "<a href='#{last_user_path}'>#{last_user}</a>".html_safe
-    end
   end
 end

--- a/app/decorators/thredded/topic_decorator.rb
+++ b/app/decorators/thredded/topic_decorator.rb
@@ -21,23 +21,5 @@ module Thredded
     def category_options
       messageboard.decorate.category_options
     end
-
-    def user_link
-      if user.anonymous?
-        user.to_s
-      else
-        user_path = Thredded.user_path(user)
-        "<a href='#{user_path}'>#{user}</a>".html_safe
-      end
-    end
-
-    def last_user_link
-      if last_user.anonymous?
-        last_user.to_s
-      else
-        last_user_path = Thredded.user_path(last_user)
-        "<a href='#{last_user_path}'>#{last_user}</a>".html_safe
-      end
-    end
   end
 end

--- a/app/helpers/thredded/application_helper.rb
+++ b/app/helpers/thredded/application_helper.rb
@@ -1,0 +1,21 @@
+module Thredded
+  module ApplicationHelper
+    # @param user [Thredded.user_class, Thredded::NullUser]
+    # @return [String] path to the user as specified by {Thredded.user_path}
+    def user_path(user)
+      Thredded.user_path(self, user)
+    end
+
+    # @param user [Thredded.user_class, Thredded::NullUser]
+    # @return [String] html_safe link to the user
+    def user_link(user)
+      render partial: 'thredded/users/link', locals: { user: user }
+    end
+
+    # @param datetime [DateTime]
+    # @return [String] html_safe datetime presentation
+    def time_ago(datetime)
+      render partial: 'thredded/shared/time_ago', locals: { datetime: datetime }
+    end
+  end
+end

--- a/app/helpers/thredded/posts_helper.rb
+++ b/app/helpers/thredded/posts_helper.rb
@@ -1,7 +1,0 @@
-module Thredded
-  module PostsHelper
-    def link_to_edit_post(_, messageboard, topic, post)
-      edit_messageboard_topic_post_path(messageboard.name, topic, post)
-    end
-  end
-end

--- a/app/models/thredded/post.rb
+++ b/app/models/thredded/post.rb
@@ -53,7 +53,8 @@ module Thredded
       %w(bbcode markdown)
     end
 
-    def filtered_content
+    # @param view_context [Object] the context of the rendering view.
+    def filtered_content(view_context)
       pipeline = HTML::Pipeline.new [
         html_filter_for_pipeline,
         HTML::Pipeline::SanitizationFilter,
@@ -62,8 +63,8 @@ module Thredded
         HTML::Pipeline::AutolinkFilter,
       ], context_options
 
-      result = pipeline.call(content)
-      result[:output].to_s
+      result = pipeline.call(content, view_context: view_context)
+      result[:output].to_s.html_safe
     end
 
     private

--- a/app/views/thredded/post_mailer/at_notification.html.erb
+++ b/app/views/thredded/post_mailer/at_notification.html.erb
@@ -1,4 +1,4 @@
-<%== @post.filtered_content %>
+<%= @post.filtered_content(self) %>
 
 <hr />
 

--- a/app/views/thredded/posts/_post.html.erb
+++ b/app/views/thredded/posts/_post.html.erb
@@ -4,13 +4,13 @@
   <%= content_tag_for :article, post do %>
     <header>
       <%= image_tag post.avatar_url, class: 'post--avatar' unless post.user_anonymous? %>
-      <h2 class="post--user"><%= post.user_link %></h2>
-      <p class="post--created-at"><%= post.created_at_timeago %></p>
+      <h2 class="post--user"><%= user_link post.user %></h2>
+      <p class="post--created-at"><%= time_ago post.created_at %></p>
 
     </header>
 
     <div class="post--content">
-      <%== post.filtered_content %>
+      <%= post.filtered_content(self) %>
     </div>
 
     <% if current_ability.can? :edit, post.original %>

--- a/app/views/thredded/private_topic_mailer/message_notification.html.erb
+++ b/app/views/thredded/private_topic_mailer/message_notification.html.erb
@@ -1,4 +1,4 @@
-<%== @topic.posts.first.filtered_content %>
+<%= @topic.posts.first.filtered_content(self) %>
 
 <hr />
 

--- a/app/views/thredded/private_topics/_private_topic.html.erb
+++ b/app/views/thredded/private_topics/_private_topic.html.erb
@@ -6,13 +6,13 @@
   </h1>
 
   <cite class="topics--updated-by">
-    <%== private_topic.updated_at_timeago %>
-    <%== private_topic.last_user_link %>
+    <%= time_ago private_topic.updated_at %>
+    <%= user_link private_topic.last_user %>
   </cite>
 
   <cite class="topics--started-by">
-    <%== private_topic.created_at_timeago %>
-    <%== private_topic.user_link %>
+    <%= time_ago private_topic.created_at %>
+    <%= user_link private_topic.user %>
   </cite>
 
   <ul class="topics--categories">

--- a/app/views/thredded/shared/_time_ago.html.erb
+++ b/app/views/thredded/shared/_time_ago.html.erb
@@ -1,0 +1,7 @@
+<% if datetime.nil? %>
+<abbr>a little while ago</abbr>
+<% else %>
+<abbr class="timeago" title="<%= datetime.getutc.iso8601 %>">
+  <%= datetime.to_s %>
+</abbr>
+<% end %>

--- a/app/views/thredded/shared/_top_nav.html.erb
+++ b/app/views/thredded/shared/_top_nav.html.erb
@@ -6,7 +6,7 @@
   <ul class="user-navigation--actions">
     <% if signed_in? %>
       <li class="main--nav--user">
-        <%= link_to Thredded.user_path(current_user) do %>
+        <%= link_to user_path(current_user) do %>
         <span><%= current_user %></span>
         <% end %>
       </li>

--- a/app/views/thredded/themes/show.html.erb
+++ b/app/views/thredded/themes/show.html.erb
@@ -48,8 +48,8 @@
     <h1><%= @topic.title %></h1>
 
     <cite class="topic--title-started-by">
-      <%== @topic.decorate.created_at_timeago %>
-      <%== @topic.decorate.user_link %>
+      <%= time_ago @topic.created_at %>
+      <%= user_link @topic.user %>
     </cite>
   </header>
 

--- a/app/views/thredded/topics/_topic.html.erb
+++ b/app/views/thredded/topics/_topic.html.erb
@@ -12,13 +12,13 @@
   </h1>
 
   <cite class="topics--updated-by">
-    <%== topic.updated_at_timeago %>
-    <%== topic.last_user_link %>
+    <%= time_ago topic.updated_at %>
+    <%= user_link topic.last_user %>
   </cite>
 
   <cite class="topics--started-by">
-    <%== topic.created_at_timeago %>
-    <%== topic.user_link %>
+    <%= time_ago topic.created_at %>
+    <%= user_link topic.user %>
   </cite>
 
   <% if topic.categories.any? %>

--- a/app/views/thredded/topics/show.html.erb
+++ b/app/views/thredded/topics/show.html.erb
@@ -17,9 +17,9 @@
 
     <cite class="topic-header--started-by">
       Started 
-      <%== topic.decorate.created_at_timeago %>
+      <%= time_ago topic.created_at %>
       by
-      <%== topic.decorate.user_link %>
+      <%= user_link topic.user %>
     </cite>
   </header>
 

--- a/app/views/thredded/users/_link.html.erb
+++ b/app/views/thredded/users/_link.html.erb
@@ -1,0 +1,9 @@
+<% if user %>
+  <% if !user.anonymous? %>
+<a href="<%= user_path(user) %>"><%= user.to_s %></a>
+  <% else %>
+<%= user.to_s %>
+  <% end %>
+<% else %>
+<em>Deleted user</em>
+<% end %>

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -12,8 +12,11 @@ Thredded.user_name_column = :name
 
 # The path (or URL) you will use to link to your users' profiles.
 # When linking to a user, Thredded will use this lambda to spit out
-# the path or url to your user.
-Thredded.user_path = ->(user) { "/users/#{user.to_param}" }
+# the path or url to your user. This lambda is evaluated in the view context.
+Thredded.user_path = lambda do |user|
+  user_path = :"#{Thredded.user_class.name.underscore}_path"
+  main_app.respond_to?(user_path) ? main_app.send(user_path, user) : "/users/#{user.to_param}"
+end
 
 # User avatar URL. Thredded uses Gravatar via the gravtastic gem by default.
 # Visit the gravtastic project - https://github.com/chrislloyd/gravtastic#usage

--- a/lib/html/pipeline/at_mention_filter.rb
+++ b/lib/html/pipeline/at_mention_filter.rb
@@ -7,10 +7,11 @@ module HTML
         super text, context, result
         @text = text.to_s.gsub "\r", ''
         @post = context[:post]
+        @view_context = context[:view_context]
       end
 
       def call
-        html = Thredded::AtUsers.render(@text, @post.messageboard)
+        html = Thredded::AtUsers.render(@text, @post.messageboard, @view_context)
         html.rstrip!
         html
       end

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -42,6 +42,7 @@ module Thredded
   self.queue_inline = false
   self.email_reply_to = -> postable { "#{postable.hash_id}@#{Thredded.email_incoming_host}" }
 
+  # @return [Class] the user class from the host application.
   def self.user_class
     if @@user_class.is_a?(Class)
       fail 'Please use a string instead of a class'
@@ -56,9 +57,12 @@ module Thredded
     end
   end
 
-  def self.user_path(user)
+  # @param view_context [Object] context to execute the lambda in.
+  # @param user [Thredded.user_class]
+  # @return [String] path to the user evaluated in the specified context.
+  def self.user_path(view_context, user)
     if @@user_path.respond_to? :call
-      @@user_path.call(user)
+      view_context.instance_exec(user, &@@user_path)
     else
       '/'
     end

--- a/lib/thredded/at_users.rb
+++ b/lib/thredded/at_users.rb
@@ -1,14 +1,15 @@
 module Thredded
   class AtUsers
-    def self.render(content, messageboard)
+    def self.render(content, messageboard, view_context)
       at_names = AtNotificationExtractor.new(content).run
 
       if at_names.any?
         members = messageboard.members_from_list(at_names)
 
         members.each do |member|
-          member_path = Thredded.user_path(member)
-          content.gsub!(/@#{member.to_s}/i, %(<a href="#{member_path}">@#{member}</a>))
+          member_path = Thredded.user_path(view_context, member)
+          content.gsub!(/(@#{member.to_s})\b/i,
+                        %(<a href="#{ERB::Util.html_escape member_path}">\\1</a>))
         end
       end
 

--- a/spec/decorators/thredded/base_topic_decorator_spec.rb
+++ b/spec/decorators/thredded/base_topic_decorator_spec.rb
@@ -17,30 +17,4 @@ module Thredded
       expect(decorated_topic.slug).to eq 'hi-topic'
     end
   end
-
-  describe BaseTopicDecorator, '#updated_at_timeago' do
-    it 'generalizes it if it is nil' do
-      topic = build_stubbed(:topic, updated_at: nil, slug: nil)
-      decorated_topic = BaseTopicDecorator.new(topic)
-      expected_html = <<-eohtml.html_safe.strip_heredoc
-        <abbr>
-          a little while ago
-        </abbr>
-      eohtml
-
-      expect(decorated_topic.updated_at_timeago).to eq expected_html
-    end
-
-    it 'creates an abbr tag with the right html and content' do
-      topic = build_stubbed(:topic, updated_at: Chronic.parse('March 1, 2015 at noon'))
-      decorated_topic = BaseTopicDecorator.new(topic)
-      expected_html = <<-eohtml.html_safe.strip_heredoc
-        <abbr class="timeago" title="2015-03-01T12:00:00Z">
-          2015-03-01 12:00:00 UTC
-        </abbr>
-      eohtml
-
-      expect(decorated_topic.updated_at_timeago).to eq expected_html
-    end
-  end
 end

--- a/spec/decorators/thredded/post_decorator_spec.rb
+++ b/spec/decorators/thredded/post_decorator_spec.rb
@@ -3,29 +3,6 @@ require 'chronic'
 require 'timecop'
 
 module Thredded
-  describe PostDecorator, '#user_link' do
-    after do
-      Thredded.user_path = nil
-    end
-
-    it 'links to a valid user' do
-      Thredded.user_path = ->(user) { "/i_am/#{user}" }
-      user = create(:user, name: 'joel')
-      post = create(:post, user: user)
-      decorator = PostDecorator.new(post)
-
-      expect(decorator.user_link).to eq "<a href='/i_am/joel'>joel</a>"
-    end
-
-    it 'links to nowhere for a null user' do
-      user = nil
-      post = create(:post, user: user)
-      decorator = PostDecorator.new(post)
-
-      expect(decorator.user_link).to eq '<a href="#">?</a>'
-    end
-  end
-
   describe PostDecorator, '#user_name' do
     it 'delegates to the user object' do
       user = build_stubbed(:user, name: 'joel')
@@ -40,38 +17,6 @@ module Thredded
       decorated_post = PostDecorator.new(post)
 
       expect(decorated_post.user_name).to eq 'Anonymous'
-    end
-  end
-
-  describe PostDecorator, '#created_at_timeago' do
-    it 'prints something ambiguous for nils' do
-      post = build_stubbed(:post)
-      allow(post).to receive_messages(created_at: nil)
-      decorated_post = PostDecorator.new(post)
-      ambiguous_message = <<-eohtml.strip_heredoc.html_safe
-        <abbr>
-          a little while ago
-        </abbr>
-      eohtml
-
-      expect(decorated_post.created_at_timeago).to eq ambiguous_message
-    end
-
-    it 'prints a human readable/formatted date' do
-      new_years = Chronic.parse('Jan 1 2013 at 3:00pm')
-
-      Timecop.freeze(new_years) do
-        post = build_stubbed(:post)
-        decorated_post = PostDecorator.new(post)
-
-        created_at_html = <<-eohtml.strip_heredoc.html_safe
-          <abbr class="timeago" title="2013-01-01T15:00:00Z">
-            2013-01-01 15:00:00 UTC
-          </abbr>
-        eohtml
-
-        expect(decorated_post.created_at_timeago).to eq created_at_html
-      end
     end
   end
 

--- a/spec/decorators/thredded/private_topic_decorator_spec.rb
+++ b/spec/decorators/thredded/private_topic_decorator_spec.rb
@@ -9,27 +9,4 @@ module Thredded
       expect(decorated_topic.css_class).to eq 'private_topic'
     end
   end
-
-  describe PrivateTopicDecorator, '#last_user_link' do
-    after do
-      Thredded.user_path = nil
-    end
-
-    it 'returns link to root if config is not set' do
-      user = build_stubbed(:user, name: 'joel')
-      topic = build_stubbed(:private_topic, last_user: user)
-      decorated_topic = PrivateTopicDecorator.new(topic)
-
-      expect(decorated_topic.last_user_link).to eq "<a href='/'>joel</a>"
-    end
-
-    it 'returns link to user if config is set' do
-      Thredded.user_path = ->(user) { "/hi/#{user}" }
-      user = build_stubbed(:user, name: 'joel')
-      topic = build_stubbed(:private_topic, last_user: user)
-      decorated_topic = PrivateTopicDecorator.new(topic)
-
-      expect(decorated_topic.last_user_link).to eq "<a href='/hi/joel'>joel</a>"
-    end
-  end
 end

--- a/spec/decorators/thredded/topic_decorator_spec.rb
+++ b/spec/decorators/thredded/topic_decorator_spec.rb
@@ -1,64 +1,6 @@
 require 'spec_helper'
 
 module Thredded
-  describe TopicDecorator, '#user_link' do
-    after do
-      Thredded.user_path = nil
-    end
-
-    it 'links to a valid user' do
-      Thredded.user_path = ->(user) { "/i_am/#{user}" }
-      user = create(:user, name: 'joel')
-      topic = create(:topic, user: user)
-      create(
-        :user_topic_read,
-        topic: topic,
-        user: user,
-      )
-      decorator = TopicDecorator.new(topic)
-
-      expect(decorator.user_link).to eq "<a href='/i_am/joel'>joel</a>"
-    end
-
-    it 'links to nowhere for a null user' do
-      topic = build_stubbed(:topic, user: nil)
-      decorator = TopicDecorator.new(topic)
-
-      expect(decorator.user_link).to eq 'Anonymous User'
-    end
-  end
-
-  describe TopicDecorator, '#last_user_link' do
-    after do
-      Thredded.user_path = nil
-    end
-
-    it 'returns "Anonymous" if nothing is there' do
-      topic = build_stubbed(:topic, last_user: nil)
-      decorated_topic = TopicDecorator.new(topic)
-
-      expect(decorated_topic.last_user_link).to eq 'Anonymous User'
-    end
-
-    it 'returns link to root if config is not set' do
-      Thredded.user_path = nil
-      user = build_stubbed(:user, name: 'joel')
-      topic = build_stubbed(:topic, last_user: user)
-      decorated_topic = TopicDecorator.new(topic)
-
-      expect(decorated_topic.last_user_link).to eq "<a href='/'>joel</a>"
-    end
-
-    it 'returns link to user if config is set' do
-      Thredded.user_path = ->(user) { "/hi/#{user}" }
-      user = build_stubbed(:user, name: 'joel')
-      topic = build_stubbed(:topic, last_user: user)
-      decorated_topic = TopicDecorator.new(topic)
-
-      expect(decorated_topic.last_user_link).to eq "<a href='/hi/joel'>joel</a>"
-    end
-  end
-
   describe TopicDecorator, '#css_class' do
     let(:user) { build_stubbed(:user) }
 

--- a/spec/decorators/thredded/user_topic_decorator_spec.rb
+++ b/spec/decorators/thredded/user_topic_decorator_spec.rb
@@ -7,10 +7,7 @@ module Thredded
       user = create(:user)
       decorator = UserTopicDecorator.new(user, topic)
 
-      expect(decorator).to respond_to(:created_at_timeago)
-      expect(decorator).to respond_to(:last_user_link)
       expect(decorator).to respond_to(:original)
-      expect(decorator).to respond_to(:updated_at_timeago)
     end
   end
 

--- a/spec/dummy/config/initializers/thredded.rb
+++ b/spec/dummy/config/initializers/thredded.rb
@@ -1,6 +1,6 @@
 Thredded.user_class = 'User'
 Thredded.user_name_column = :name
-Thredded.user_path = ->(user) { "/users/#{user.to_param}" }
+Thredded.user_path = ->(user) { main_app.user_path(user.to_param) }
 Thredded.email_incoming_host = 'incoming.example.com'
 Thredded.email_from = 'no-reply@example.com'
 Thredded.email_outgoing_prefix = '[Thredded] '

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   delete '/session' => 'sessions#destroy'
 
   resources :sessions, only: [:new, :create, :destroy]
-  resources :users, only: [:show]
+  resources :users, only: [:show], path: 'u'
 
   mount Thredded::Engine => '/thredded'
 end

--- a/spec/lib/thredded_spec.rb
+++ b/spec/lib/thredded_spec.rb
@@ -46,27 +46,27 @@ describe Thredded, '.queue_inline' do
 end
 
 describe Thredded, '.user_path' do
-  after do
-    Thredded.user_path = nil
-  end
-
   it 'returns "/" if lambda is not set' do
-    expect(Thredded.user_path(nil)).to eq '/'
+    Thredded.user_path = nil
+    expect(Thredded.user_path(_view_context = nil, _user = nil)).to eq '/'
   end
 
   context 'lambda is created and called with a user' do
     it 'returns one path' do
       me = build_stubbed(:user, name: 'joel')
       Thredded.user_path = ->(user) { "/my/name/is/#{user}" }
-
-      expect(Thredded.user_path(me)).to eq '/my/name/is/joel'
+      expect(Thredded.user_path(_view_context = nil, _user = me)).to eq '/my/name/is/joel'
     end
 
     it 'returns another path' do
       you = build_stubbed(:user, name: 'carl')
       Thredded.user_path = ->(user) { "/wow/so/#{user}" }
+      expect(Thredded.user_path(_view_context = nil, _user = you)).to eq '/wow/so/carl'
+    end
 
-      expect(Thredded.user_path(you)).to eq '/wow/so/carl'
+    it 'executes in the given context' do
+      Thredded.user_path = ->(_user) { reverse }
+      expect(Thredded.user_path(_view_context = 'abc', _user = nil)).to eq 'cba'
     end
   end
 end

--- a/spec/support/features/page_object/user.rb
+++ b/spec/support/features/page_object/user.rb
@@ -18,7 +18,7 @@ module PageObject
     end
 
     def load_page
-      visit Thredded.user_path(@user)
+      visit Thredded.user_path(nil, @user)
     end
 
     def displaying_the_profile?

--- a/spec/views/thredded/shared/time_ago_spec.rb
+++ b/spec/views/thredded/shared/time_ago_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe 'partial: thredded/shared/time_ago' do
+  def render_partial(datetime)
+    render partial: 'thredded/shared/time_ago', locals: { datetime: datetime }
+  end
+
+  it 'renders a datetime' do
+    render_partial Chronic.parse('March 1, 2015 at noon')
+    expect(rendered).to eq(<<-HTML.strip_heredoc)
+      <abbr class="timeago" title="2015-03-01T12:00:00Z">
+        2015-03-01 12:00:00 UTC
+      </abbr>
+    HTML
+  end
+
+  it 'with nil, something ambiguous' do
+    render_partial nil
+    expect(rendered).to eq <<-HTML.strip_heredoc
+      <abbr>a little while ago</abbr>
+    HTML
+  end
+end

--- a/spec/views/thredded/user/link_spec.rb
+++ b/spec/views/thredded/user/link_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe 'partial: thredded/users/link' do
+  def render_partial(user)
+    render partial: 'thredded/users/link', locals: { user: user }
+  end
+
+  it 'renders a link to the user' do
+    render_partial build_stubbed(:user, name: 'joel')
+    expect(rendered).to eq(<<-HTML.strip_heredoc)
+      <a href="/u/joel">joel</a>
+    HTML
+  end
+
+  it 'with null user' do
+    user = Thredded::NullUser.new
+    render_partial user
+    expect(rendered).to eq <<-HTML.strip_heredoc
+      #{user}
+    HTML
+  end
+
+  it 'with nil user' do
+    render_partial nil
+    expect(rendered).to eq <<-HTML.strip_heredoc
+      <em>Deleted user</em>
+    HTML
+  end
+end


### PR DESCRIPTION
* Execute user_path in the view context. Provide intelligent default. #117
* Move HTML rendering of user links and timestamps into partials.
  This simplifies the code and the tests, and makes customization easier.
  Not sure if I am overlooking some benefit of doing this in the decorator?