### PR TITLE
travis: cache the gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,9 @@
 
 AllCops:
   Exclude:
-    - !ruby/regexp /.*\/schema\.rb$/
-    - !ruby/regexp /\/db\/schema\.(postgresql|mysql2)\.rb$/
-    - !ruby/regexp /\/db\/migrate\/.*/
+    - 'db/**/*'
+    - 'spec/dummy/db/**/*'
+    - 'vendor/**/*'
 
 AbcSize:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rvm:
   - 2.1.0
   - 2.2.0
 
+cache: bundler
+bundler_args: --path ../../vendor/bundle
 gemfile:
   - spec/gemfiles/rails_4_0.gemfile
   - spec/gemfiles/rails_4_1.gemfile


### PR DESCRIPTION
Cache the dependencies as per
http://docs.travis-ci.com/user/caching/#Caching-directories-(Bundler%2C-dependencies)

Should speed up the build quite a bit, `bundle install` currently takes 1:30m on travis.