### PR TITLE
Sort out the dependencies and test only on Ruby 2.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: ruby
 
 rvm:
-  - 2.0.0
-  - 2.1.0
-  - 2.2.0
+  - 2.2
 
 cache: bundler
-bundler_args: --path ../../vendor/bundle
+bundler_args: --path ../../vendor/bundle --without debug
 gemfile:
   - spec/gemfiles/rails_4_0.gemfile
   - spec/gemfiles/rails_4_1.gemfile
@@ -21,7 +19,8 @@ sudo: false
 
 before_script: "RAILS_ENV=test bundle exec rake db:create db:migrate"
 
-script: "bundle exec rake"
+# Avoid rake here, as the RSpec test task spawns a new process which does not run via bundler.
+script: "bundle exec rspec && bundle exec rubocop"
 
 notifications:
   slack:

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,13 @@
 source 'https://rubygems.org'
 gemspec
+
+group :debug do
+  gem 'derailed'
+  gem 'pry-rails'
+  gem 'rack-mini-profiler'
+  platform :mri do
+    gem 'byebug'
+    gem 'flamegraph'
+    gem 'stackprof'
+  end
+end

--- a/README.mkdn
+++ b/README.mkdn
@@ -1,6 +1,6 @@
 # Thredded [![Code Climate](https://codeclimate.com/github/jayroh/thredded/badges/gpa.svg)](https://codeclimate.com/github/jayroh/thredded) [![Travis-CI](https://api.travis-ci.org/jayroh/thredded.svg?branch=master)](https://travis-ci.org/jayroh/thredded/) [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/jayroh/thredded?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-_Thredded_ is a rails 4+ forum/messageboard engine. Its goal is to be as
+_Thredded_ is a Rails 4+ forum/messageboard engine. Its goal is to be as
 simple and feature rich as possible.
 
 If you're looking for variations on a theme - see [Discourse], [Forem],
@@ -17,6 +17,8 @@ is an engine - not a standalone app.
 [Tectura]: https://github.com/caelum/tectura
 [Heterotic Beast]: https://github.com/distler/heterotic_beast
 [Altered Beast]: https://www.github.com/courtenay/altered_beast
+
+Currently only MRI Ruby 2.2+ is supported. We would love to support JRuby and Rubinius as well.
 
 ## Installation
 

--- a/app/models/thredded/post.rb
+++ b/app/models/thredded/post.rb
@@ -93,7 +93,7 @@ module Thredded
             return if node_name != 'iframe'
             return if (node['src'] =~ %r{\A(https?:)?//(?:www\.)?youtube(?:-nocookie)?\.com/}).nil?
 
-            Sanitize.clean_node!(
+            Sanitize.node!(
               node,
               elements: %w(iframe),
               attributes: {

--- a/lib/generators/thredded/install/install_generator.rb
+++ b/lib/generators/thredded/install/install_generator.rb
@@ -2,9 +2,9 @@ module Thredded
   module Generators
     class InstallGenerator < Rails::Generators::Base
       class_option :theme,
-        type: :boolean,
-        default: false,
-        desc: 'Copy all thredded layout, views, and assets to parent application.'
+                   type:    :boolean,
+                   default: false,
+                   desc:    'Copy all thredded layout, views, and assets to parent application.'
 
       def set_source_paths
         @source_paths = [
@@ -49,43 +49,6 @@ module Thredded
         directory \
           'app/assets/images/thredded',
           'vendor/assets/images/thredded'
-      end
-
-      def add_dependencies
-        return if no_gems_to_install? || !options.theme?
-
-        line_in_gemfile = in_gemfile?('ruby') ? /^ruby .*$/ : /^source.*$/
-        inject_into_file 'Gemfile', gems, after: line_in_gemfile
-        notify_of_installation
-      end
-
-      private
-
-      def no_gems_to_install?
-        gems.chomp.empty?
-      end
-
-      def gems
-        gems = "\n"
-        gems << "\ngem 'bourbon'"       unless in_gemfile?('bourbon')
-        gems << "\ngem 'neat'"          unless in_gemfile?('neat')
-        gems << "\ngem 'bitters'"       unless in_gemfile?('bitters')
-        gems << "\ngem 'sprockets-es6'" unless in_gemfile?('sprockets-es6')
-
-        gems
-      end
-
-      def in_gemfile?(gem_name)
-        gemfile.include?(gem_name)
-      end
-
-      def gemfile
-        @gemfile ||= File.read('Gemfile')
-      end
-
-      def notify_of_installation
-        text = "\n\tNew gems have been added to the Gemfile. Make sure to `bundle install`.\n"
-        puts "\e[32m#{text}\e[0m"
       end
     end
   end

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -1,14 +1,22 @@
-require 'thredded/engine'
+# Backend
 require 'cancan'
-require 'kaminari'
 require 'friendly_id'
 require 'gravtastic'
+require 'html/pipeline'
+require 'html/pipeline/at_mention_filter'
+require 'html/pipeline/bbcode_filter'
+require 'kaminari'
 require 'q'
 require 'threaded_in_memory_queue'
+
+# Asset compilation
+require 'bitters'
+require 'bourbon'
+require 'neat'
+require 'sprockets/es6'
+
+require 'thredded/engine'
 require 'thredded/errors'
-require 'html/pipeline'
-require 'html/pipeline/bbcode_filter'
-require 'html/pipeline/at_mention_filter'
 require 'thredded/messageboard_user_permissions'
 require 'thredded/post_user_permissions'
 require 'thredded/private_topic_user_permissions'

--- a/spec/features/thredded/user_views_private_topics_spec.rb
+++ b/spec/features/thredded/user_views_private_topics_spec.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'spec_helper'
 
 feature 'User viewing private topics' do

--- a/spec/lib/thredded_spec.rb
+++ b/spec/lib/thredded_spec.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'spec_helper'
 
 describe Thredded, '.queue_backend' do

--- a/spec/support/features/page_object/topics.rb
+++ b/spec/support/features/page_object/topics.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'support/features/page_object/base'
 
 module PageObject

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -13,26 +13,30 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.description = 'A messageboard engine for Rails 4.0 apps'
 
+  # backend
   s.add_dependency 'bbcoder', '~> 1.0'
   s.add_dependency 'cancancan'
-  s.add_dependency 'escape_utils'
   s.add_dependency 'friendly_id'
-  s.add_dependency 'gemoji'
-  s.add_dependency 'github-markdown'
   s.add_dependency 'gravtastic'
   s.add_dependency 'html-pipeline'
   s.add_dependency 'htmlentities'
   s.add_dependency 'kaminari'
-  s.add_dependency 'multi_json'
   s.add_dependency 'nokogiri'
   s.add_dependency 'q'
   s.add_dependency 'rails', '>= 4.0.0'
+
+  # html-pipeline dependencies, see https://github.com/jch/html-pipeline#dependencies
+  s.add_dependency 'gemoji'
+  s.add_dependency 'github-markdown'
   s.add_dependency 'rinku'
   s.add_dependency 'sanitize'
+
+  # frontend
   s.add_dependency 'bourbon'
   s.add_dependency 'neat'
   s.add_dependency 'bitters'
   s.add_dependency 'sprockets-es6'
+  s.add_dependency 'jquery-rails'
 
   # test dependencies
   s.add_development_dependency 'capybara', '~> 2.4'
@@ -43,24 +47,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rubocop', '0.32.0'
   s.add_development_dependency 'shoulda-matchers', '~> 2.7'
-  s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'timecop'
   s.add_development_dependency 'test-unit'
+  s.add_development_dependency 'timecop'
 
   # dummy app dependencies
-  s.add_development_dependency 'jquery-rails'
-  s.add_development_dependency 'pg'
   s.add_development_dependency 'mysql2'
+  s.add_development_dependency 'pg'
   s.add_development_dependency 'puma'
-
-  # debug dependencies
-  s.add_development_dependency 'byebug'
-  s.add_development_dependency 'flamegraph'
-  s.add_development_dependency 'pry-rails'
-  s.add_development_dependency 'rack-mini-profiler'
-  s.add_development_dependency 'derailed'
-
-  if RUBY_VERSION != '2.0.0'
-    s.add_development_dependency 'stackprof'
-  end
 end


### PR DESCRIPTION
* Further group the dependencies by type.
* Separate out the debugging dependencies (not needed on travis).
* Move `jquery-rails` from development to runtime.
* Remove development dependency on sqlite3 (not needed).
* Generator no longer adds gems to the user's Gemfile.