### PR TITLE
Correct location of template

### DIFF
--- a/lib/generators/thredded/install/install_generator.rb
+++ b/lib/generators/thredded/install/install_generator.rb
@@ -23,7 +23,7 @@ module Thredded
         return unless options.theme?
 
         copy_file \
-          'app/views/layouts/thredded.html.erb',
+          'app/views/layouts/thredded/application.html.erb',
           'vendor/views/layouts/thredded.html.erb'
 
         directory \


### PR DESCRIPTION
`app/views/layouts/thredded.html.erb` does not exist, but
`app/views/layouts/thredded/application.html.erb` does. This change allows `rails
generate thredded:install --theme` to work.

It is possible that I did something wrong while trying to integrate Thredded into my app, and that this change is completely misguided. Thanks in advance for taking a look at this PR.