### PR TITLE
Removes the last instance of the old timeago

### DIFF
--- a/app/decorators/thredded/messageboard_decorator.rb
+++ b/app/decorators/thredded/messageboard_decorator.rb
@@ -19,18 +19,6 @@ module Thredded
       "#{topics_count} topics / #{posts_count} posts".downcase
     end
 
-    def latest_topic_timeago
-      if latest_topic.updated_at.nil?
-        '<abbr>a little while ago</abbr>'
-      else
-        <<-eohtml.html_safe
-          <abbr class="timeago" title="#{topic_updated_at_utc}">
-            #{topic_updated_at_str}
-          </abbr>
-        eohtml
-      end
-    end
-
     def latest_topic
       @latest_topic ||= begin
         messageboard.topics.order_latest_first.first ||

--- a/app/models/thredded/null_topic.rb
+++ b/app/models/thredded/null_topic.rb
@@ -1,15 +1,15 @@
 module Thredded
   class NullTopic
     def updated_at
-      Time.now
+      nil
     end
 
     def user
-      'Anonymous User'
+      Thredded::NullUser.new
     end
 
     def last_user
-      'Anonymous User'
+      Thredded::NullUser.new
     end
   end
 end

--- a/app/views/thredded/messageboards/_messageboard.html.erb
+++ b/app/views/thredded/messageboards/_messageboard.html.erb
@@ -8,7 +8,7 @@
     <p class="messageboard--description"><%= messageboard.description %></p>
 
     <p class="messageboard--byline">
-      Updated <%= messageboard.latest_topic_timeago %>
+      Updated <%= time_ago messageboard.latest_topic.updated_at %>
       <cite>by <%= messageboard.latest_user %></cite>
     </p>
   <% end %>

--- a/spec/decorators/thredded/messageboard_decorator_spec.rb
+++ b/spec/decorators/thredded/messageboard_decorator_spec.rb
@@ -40,23 +40,4 @@ module Thredded
       expect(decorated_messageboard.latest_user).to eq them
     end
   end
-
-  describe MessageboardDecorator, '#latest_topic_timeago' do
-    it 'spits out an abbr tag with the right markup for timeago' do
-      new_years = Chronic.parse('Jan 1 2013 at 3:00pm')
-
-      Timecop.freeze(new_years) do
-        messageboard = create(:messageboard)
-        create(:topic, messageboard: messageboard, updated_at: new_years)
-        decorated_messageboard = MessageboardDecorator.new(messageboard)
-        abbr = <<-abbr
-          <abbr class="timeago" title="2013-01-01T15:00:00Z">
-            2013-01-01 15:00:00 UTC
-          </abbr>
-        abbr
-
-        expect(decorated_messageboard.latest_topic_timeago).to eq abbr
-      end
-    end
-  end
 end

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'neat'
   s.add_dependency 'bitters'
   s.add_dependency 'rails-timeago'
-  s.add_dependency 'select2-rails'
+  s.add_dependency 'select2-rails', '~> 3.5'
   s.add_dependency 'autosize-rails'
   s.add_dependency 'sprockets-es6'
   s.add_dependency 'jquery-rails'


### PR DESCRIPTION

Also, locks select2-rails at 3.5 as the newly released 4.0.1 has issues.