### PR TITLE
[JRO] Small fixes/optimizations for 2 shell scripts

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -131,10 +131,12 @@ To be more clear - these are some dependencies for when you are working on *this
 
 * PostgreSQL & MySQL - `brew install postgres mysql`
 
-Then, create the `thredded` database users for both MySQL and Postgres:
+Then, create the `thredded` database users for both MySQL and Postgres. Optional
+ENV's you can use are to specify the db's - `DB=postgresql` or `DB=mysql2` - or
+the user account that postgresql is running as - `PG_DAEMON_USER=$(whoami)`.
 
 ```console
-$ script/create-db-users
+$ [DB=postgresql|mysql2] [PG_DAEMON_USER=$(whoami)] script/create-db-users
 ```
 
 If and when you generate new migrations for thredded there will be three database migrations and one schema dump you will want to run.
@@ -144,9 +146,16 @@ If and when you generate new migrations for thredded there will be three databas
 3. `RAILS_ENV=test bundle exec rake db:drop db:create db:migrate`
 4. `bundle exec rake db:schema:dump`
 
-The first two are to generate the db schemas for both postgres and mysql, the third is to migrate your local test database, and the last is to take that schema information and save it to the two schema files (for when it tests against PG and MySql)
+The first two, in the steps above, are to generate the db schemas for both
+postgres and mysql, the third is to migrate your local test database, and the
+last is to take that schema information and save it to the two schema files
+(for when it tests against PG and MySql).
 
-*OR* you can just run `script/migrate`!
+*Or*, use the included script (it's got all that good stuff in it)
+
+```console
+$ script/migrate
+```
 
 Finally, run the development server with either `DB=postgresql` or `DB=mysql2`:
 

--- a/script/create-db-users
+++ b/script/create-db-users
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+GREEN='\033[0;32m'
+RESET_COLOR='\033[0m'
+
 if [ -n "$1" ]; then cat <<'HELP'; exit; fi
 Usage: script/create-db-users
 Create the thredded database users for all the supported databases.
@@ -7,10 +10,10 @@ If the `DB` environment variable is set, do the above only for that database.
 HELP
 
 set -e
-log() { if [ -t 1 ]; then echo -e >&2 "\e[0;36m$@\e[0m"; else echo >&2 "$@"; fi }
+log() { if [ -t 1 ]; then echo -e >&2 "${GREEN}$@${RESET_COLOR}"; else echo >&2 "$@"; fi }
 
 create_mysql_user() {
-  log 'Creating MySQL thredded user. MySQL root password required.'
+  log "\nCreating MySQL thredded user. MySQL root password required.\n"
   mysql --verbose -uroot -p <<'SQL'
 -- This will create a user if one does not exist.
 GRANT ALL PRIVILEGES ON `thredded_gem_dev`.* TO 'thredded'@'localhost' IDENTIFIED BY 'thredded';
@@ -19,8 +22,8 @@ SQL
 }
 
 create_postgresql_user() {
-  log 'Creating Postgres thredded user. Sudo / root required.'
-  sudo -u postgres psql --echo-all postgres <<'SQL'
+  log "\nCreating Postgres thredded user. Sudo / root required.\n"
+  sudo -u $PG_DAEMON_USER psql --echo-all postgres <<'SQL'
 DO
 $body$
 BEGIN
@@ -33,5 +36,6 @@ $body$
 SQL
 }
 
+[ -z "$PG_DAEMON_USER" ] && PG_DAEMON_USER=postgres
 [ -z "$DB" -o "$DB" = 'mysql2' ] && create_mysql_user
 [ -z "$DB" -o "$DB" = 'postgresql' ] && create_postgresql_user

--- a/script/migrate
+++ b/script/migrate
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+GREEN='\033[0;32m'
+RESET_COLOR='\033[0m'
+
 if [ -n "$1" ]; then cat <<'HELP'; exit; fi
 Usage: script/migrate
 Re-create the database schemas, run the migrations, dump the schemas, and seed all the supported databases.
@@ -7,7 +10,7 @@ If the `DB` environment variable is set, do the above only for that database.
 HELP
 
 set -e
-log() { if [ -t 1 ]; then echo -e >&2 "\e[0;36m$@\e[0m"; else echo >&2 "$@"; fi }
+log() { if [ -t 1 ]; then echo -e >&2 "${GREEN}$@${RESET_COLOR}"; else echo >&2 "$@"; fi }
 
 if [ -z "$DB" ]; then
   declare -a DBS=(mysql2 postgresql)

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,7 +1,15 @@
+<%
+db_adapter = ENV.fetch('DB', 'postgresql')
+db_adapter_port = db_adapter == 'postgresql' ? 5432 : 3306
+
+db_host = ENV.fetch('DB_HOST', ENV.fetch('THREDDED_DB_1_PORT_5432_TCP_ADDR', 'localhost'))
+db_port = ENV.fetch('DB_PORT', ENV.fetch('THREDDED_DB_1_PORT_5432_TCP_ADDR', db_adapter_port))
+%>
+
 defaults: &defaults
-  host: <%= ENV.fetch('THREDDED_DB_1_PORT_5432_TCP_ADDR', 'localhost') %>
-  port: <%= ENV.fetch('THREDDED_DB_1_PORT_5432_TCP_PORT', 5432) %>
-  adapter: <%= ENV.fetch('DB', 'postgresql') %>
+  host: <%= db_host %>
+  port: <%= db_port %>
+  adapter: <%= db_adapter %>
   encoding: utf8
   min_messages: WARNING
   username: <%= ENV.fetch('DB_USERNAME', 'thredded').inspect %>


### PR DESCRIPTION
The create-db-users script does not take into account the fact that the postgresql daemon may be running as another user account on the system so this commit defaults it to `postgres` but allows being overridden by the PG_DAEMON_USER environment variable. This use case is semi-common if a developer is using something like [Postgres.app][] from Heroku.

Both `script/migrate` and `script/create-db-users` were logging out to STDOUT with escape codes that were not being interpreted, so this commit also adds descriptive ENV variables denoting that they will come out colored green.

`database.yml` was defaulting to the postgres port and would not work if using mysql, so pulling those into variables in the yaml file makes it a little easier to discern what the values are that are being set.

Lastly, some accompanying README edits to make things more clear (possible options, etc).

[Postgres.app]: http://postgresapp.com/