### PR TITLE
Mark #signed_in? as a helper method in the application controller

### DIFF
--- a/app/controllers/thredded/application_controller.rb
+++ b/app/controllers/thredded/application_controller.rb
@@ -7,7 +7,8 @@ module Thredded
       :active_users,
       :messageboard,
       :preferences,
-      :unread_private_topics_count
+      :unread_private_topics_count,
+      :signed_in?
 
     rescue_from \
       CanCan::AccessDenied,


### PR DESCRIPTION
The _top_nav partial relies on #signed_in? however it was not previously available to the view.

https://github.com/jayroh/thredded/blob/e2dc1e1e4a94bb7b98ea80b635e55b4aee5e5dd2/app/views/thredded/shared/_top_nav.html.erb#L8