### PR TITLE
Only show the button to create a new messageboard when permitted to

### DIFF
--- a/app/views/thredded/messageboards/index.html.erb
+++ b/app/views/thredded/messageboards/index.html.erb
@@ -12,7 +12,9 @@
     <%= render @messageboards %>
   </section>
 
-  <div class="messageboard--create">
-    <%= link_to 'Create a New Messageboard', new_messageboard_path, class: 'button' %>
-  </div>
+  <% if current_ability.can? :create, Thredded::Messageboard %>
+    <div class="messageboard--create">
+      <%= link_to 'Create a New Messageboard', new_messageboard_path, class: 'button' %>
+    </div>
+  <% end %>
 <% end %>

--- a/spec/views/thredded/messageboards/index.html.erb_spec.rb
+++ b/spec/views/thredded/messageboards/index.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe 'thredded/messageboards/index' do
+  before do
+    # Give view access to route helpers and general helper methods
+    view.extend Thredded::Engine.routes.url_helpers
+    view.extend Thredded::ApplicationHelper
+
+    # Set up instance variables
+    assign(:messageboards, [])
+
+    # Stub the helper methods defined in the controller
+    allow(view).to receive_messages(messageboard: nil, active_users: [])
+
+    # Use a generic Ability model so we can grant abilities on the fly
+    allow(view).to receive(:current_ability).and_return(Object.new.extend(CanCan::Ability))
+  end
+
+  it 'shows the Create button when permitted to create a messageboard' do
+    view.current_ability.can(:create, Thredded::Messageboard)
+
+    render
+
+    expect(rendered).to have_link('Create a New Messageboard')
+  end
+
+  it 'does not show the Create button when not permitted to create a messageboard' do
+    render
+
+    expect(rendered).to_not have_link('Create a New Messageboard')
+  end
+end


### PR DESCRIPTION
The controller already authorizes creating a messageboard, so showing the button when the user is not permitted to create a messageboard is misleading to users.

I opted to use a fresh ability model rather than the `Thredded::Ability` model in the test so that the view could simply grant the abilities we want to test against, rather than worry about getting the view spec's state into a scenario where the ability would normally be granted (such as making the user a superadmin).