### PR TITLE
Apply button styling to elements with the "button" class

### DIFF
--- a/app/assets/stylesheets/thredded/base/_buttons.scss
+++ b/app/assets/stylesheets/thredded/base/_buttons.scss
@@ -1,3 +1,4 @@
+.button,
 #{$all-buttons} {
   appearance: none;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
368c35c4 stopped applying the button styling to elements with the "button" class.

bourbon's `$all-buttons` variable only includes native button-like elements, not any general element to be styled like a button:
https://github.com/thoughtbot/bourbon/blob/ac307d9981cce5ae4d3aadbf41e9b15503b68bb4/core/bourbon/library/_buttons.scss#L50-L57